### PR TITLE
Deployment-time configuration of front end application

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,12 +1,15 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
-
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { AppConfigService } from './providers/app-config.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 
+export function initConfig(appConfig: AppConfigService) {
+  return () => appConfig.loadConfig();
+}
 
 @NgModule({
   declarations: [
@@ -20,7 +23,12 @@ import { FooterComponent } from './components/footer/footer.component';
     BrowserAnimationsModule
   ],
   
-  providers: [],
+  providers: [{
+    provide: APP_INITIALIZER,
+    useFactory: initConfig,
+    deps: [AppConfigService],
+    multi: true,
+  }],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/providers/app-config.service.spec.ts
+++ b/src/app/providers/app-config.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AppConfigService } from './app-config.service';
+
+describe('AppConfigService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: AppConfigService = TestBed.get(AppConfigService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/providers/app-config.service.ts
+++ b/src/app/providers/app-config.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { environment } from '../../environments/environment';
+
+@Injectable({
+  providedIn: "root",
+})
+export class AppConfigService {
+  private config: any = environment;
+  constructor(private http: HttpClient) { }
+
+  public async loadConfig() {
+    if ("configFile" in environment) {
+      try {
+        const config = await this.http
+          .get(environment["configFile"])
+          .toPromise();
+        this.config = Object.assign({}, environment, config);
+        console.log(this.config);
+      }
+      catch (err) {
+        console.error(err);
+      }
+    }
+  }
+
+  getConfig() {
+    return this.config;
+  }
+}

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -1,16 +1,20 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { environment } from '../../environments/environment';
+import { AppConfigService } from '../providers/app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 
 export class DataService {
-  apiUrl = environment.apiBaseUrl;
 
-  constructor(private httpClient: HttpClient) { }
+  apiUrl = null;
+
+  constructor(private httpClient: HttpClient, private config: AppConfigService) { 
+    this.apiUrl = this.config.getConfig().apiBaseUrl;
+    console.log(this.config.getConfig());
+  }
 
   processImage(fileLocation: string): Observable<HttpResponse<any>> {
     const url = this.apiUrl.concat('/processImage');

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,0 +1,3 @@
+{
+    "apiBaseUrl": "https://jenkins-master-deephealth-unix01.ing.unimore.it/backend"
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://jenkins-master-deephealth-unix01.ing.unimore.it/backend'
+  // Use 'config.json' asset to configure API url at runtime
+  configFile: '/assets/config.json'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,11 @@
 export const environment = {
   production: false,
   // apiBaseUrl: 'http://localhost:5000'
-  apiBaseUrl: 'https://jenkins-master-deephealth-unix01.ing.unimore.it/backend'
+  apiBaseUrl: 'https://jenkins-master-deephealth-unix01.ing.unimore.it/backend',
+  // 'configFile' is a path to an asset JSON file containing additional 
+  // settings that can be set without rebuild. They can be accessed 
+  // through the 'AppConfigService'
+  // configFile: '/assets/config.json'
 };
 
 /*


### PR DESCRIPTION
This PR allows the web service endpoint to be configured as the application is being deployed -- rather than at compile time.  This change is required to support the deployment on Kubernetes of the DeepHealth front end application.